### PR TITLE
Excluded backup files from install

### DIFF
--- a/src/Shared/Config.yaml
+++ b/src/Shared/Config.yaml
@@ -16,6 +16,7 @@ ModInstall:
   - upgrade
   - vehicles
   ExcludedFromInstall:
+  - '**\*.orig'
   - '**\*.dll'
   - '**\*.exe'
   ExcludedFromConfig:


### PR DESCRIPTION
Modders are not only using the `bak` extension, but now also `orig` (e.g. Lotus Exige mod) 😠 We are going to exclude those files to avoid errors. For sure they can't be needed!